### PR TITLE
Rename intro to FAQ in the website so it shows up

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,5 +1,5 @@
 - file: README
-- file: FAQ
+- file: intro
 - file: meetings
   sections:
     - file: "meetings/3_02_2021"


### PR DESCRIPTION
Right now the "Intro" page doesn't show up in the website sidebar, because it was renamed from FAQ. This updates the table of contents (toc) to include the updated name .

Before:

![](https://user-images.githubusercontent.com/1186124/109824704-1098d980-7c07-11eb-8327-c68d325d6484.png)